### PR TITLE
Fix script path handling

### DIFF
--- a/diff_dir_2html.sh
+++ b/diff_dir_2html.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Ensure script runs from its own directory so relative paths work
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
 # Orquesta:
 # 1) Genera diff coloreado con ignores y regex extras
 # 2) Convierte a HTML preliminar con aha


### PR DESCRIPTION
## Summary
- ensure `diff_dir_2html.sh` runs from its own folder

## Testing
- `diff_dir_2html.sh` with no args from /tmp (shows usage)

------
https://chatgpt.com/codex/tasks/task_e_6851a24c263483309c6a3e66c3d27079