### PR TITLE
Fix README stylesheet name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The script produces an HTML page where every file diff can be expanded or collap
 - `diff_collapse.js` – adds collapsible sections and injects metadata.
 - `diff_style.css` – minimal styles for the page.
 
-The HTML template `diff_template.html.j2` and optional stylesheet `diff_collapse.css` are expected to be present when invoking the script.
+The HTML template `diff_template.html.j2` and optional stylesheet `diff_style.css` are expected to be present when invoking the script.
 
 ## License
 


### PR DESCRIPTION
## Summary
- correct CSS filename in README

## Testing
- `bash -n diff_dir_2html.sh`
- `python3 -m py_compile assemble_diff.py`


------
https://chatgpt.com/codex/tasks/task_e_6851e62b48bc833093892a156fa8918d