### PR TITLE
Use context manager for file reads

### DIFF
--- a/assemble_diff.py
+++ b/assemble_diff.py
@@ -4,10 +4,14 @@ import jinja2
 def main(template_path, diff_html_path, css_path, js_path,
          name1, name2, excludes, output_path):
     # Leer recursos
-    tpl = jinja2.Template(open(template_path).read())
-    css = open(css_path).read()
-    js = open(js_path).read()
-    diff_html = open(diff_html_path).read()
+    with open(template_path) as f:
+        tpl = jinja2.Template(f.read())
+    with open(css_path) as f:
+        css = f.read()
+    with open(js_path) as f:
+        js = f.read()
+    with open(diff_html_path) as f:
+        diff_html = f.read()
 
     rendered = tpl.render(
         name1=name1,


### PR DESCRIPTION
## Summary
- use `with open()` when reading template, style, script and diff files

## Testing
- `python3 -m py_compile assemble_diff.py`

------
https://chatgpt.com/codex/tasks/task_e_6851e65a5eb48330aba67b994fe27e8c