### PR TITLE
Switch to argparse for python entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@
 ./diff_dir_2html.sh [-e PATTERN] <dir1> <dir2> [output]
 ```
 
-- `-e PATTERN` can be repeated to exclude files matching a pattern.
+- `-e PATTERN` can be repeated to exclude files whose path matches a POSIX
+extended regular expression.
 - `<dir1>` and `<dir2>` are the directories to compare.
-- `[output]` optional path to the resulting HTML file. If omitted, a name based on the directory names and git revisions is generated.
+- `[output]` optional path to the resulting HTML file. If omitted, a name based on the directory names and git revisions is generated. If the path ends with `/`, the directory is created and a filename is generated automatically.
+
+Exclude patterns are applied after the directories are copied to a temporary location, so files matching the patterns do not appear in the diff.
 
 The script produces an HTML page where every file diff can be expanded or collapsed individually.
 

--- a/assemble_diff.py
+++ b/assemble_diff.py
@@ -1,4 +1,5 @@
-import sys
+#!/usr/bin/env python3
+import argparse
 import jinja2
 
 def main(template_path, diff_html_path, css_path, js_path,
@@ -21,8 +22,26 @@ def main(template_path, diff_html_path, css_path, js_path,
         f.write(rendered)
 
 if __name__ == '__main__':
-    # Parámetros: template, diff.html, css, js, name1, name2, excludes..., output
-    template, diff_html, css, js, name1, name2 = sys.argv[1:7]
-    excludes = sys.argv[7:-1]
-    output = sys.argv[-1]
-    main(template, diff_html, css, js, name1, name2, excludes, output)
+    parser = argparse.ArgumentParser(description="Combine diff HTML with template")
+    parser.add_argument("--template", required=True, help="Jinja2 template path")
+    parser.add_argument("--diff-html", required=True, dest="diff_html",
+                        help="HTML produced from git diff")
+    parser.add_argument("--css", required=True, help="CSS file path")
+    parser.add_argument("--js", required=True, help="JS file path")
+    parser.add_argument("--name1", required=True, help="Name of first directory")
+    parser.add_argument("--name2", required=True, help="Name of second directory")
+    parser.add_argument("--exclude", action="append", default=[],
+                        help="Exclude patterns")
+    parser.add_argument("--output", required=True, help="Output HTML path")
+    args = parser.parse_args()
+
+    main(
+        args.template,
+        args.diff_html,
+        args.css,
+        args.js,
+        args.name1,
+        args.name2,
+        args.exclude,
+        args.output,
+    )

--- a/diff_dir_2html.sh
+++ b/diff_dir_2html.sh
@@ -20,7 +20,7 @@ EX=()
 while getopts ":e:" o; do case $o in e) EX+=("$OPTARG");; *) usage;; esac; done
 shift $((OPTIND-1))
 [[ $# -ge 2 && $# -le 3 ]] || usage
-DIR1=$1; DIR2=$2; OUT=${3:-}
+DIR1=$1; DIR2=$2; RAW_OUT=${3-}
 
 # Convert directories to absolute paths before leaving caller directory
 DIR1=$(realpath "$DIR1")
@@ -32,10 +32,16 @@ H1=$(git -C "$DIR1" rev-parse --short=8 HEAD 2>/dev/null || echo fallback)
 H2=$(git -C "$DIR2" rev-parse --short=8 HEAD 2>/dev/null || echo fallback)
 
 # Output path, default relative to original directory
-if [[ -z "$OUT" ]]; then
+if [[ -z "$RAW_OUT" ]]; then
   OUT="$ORIG_PWD/diff_${N1}-${H1}_${N2}-${H2}.html"
 else
-  OUT=$(realpath -m "$OUT")
+  if [[ "$RAW_OUT" == */ ]]; then
+    OUT_DIR=$(realpath -m "$RAW_OUT")
+    mkdir -p "$OUT_DIR"
+    OUT="$OUT_DIR/diff_${N1}-${H1}_${N2}-${H2}.html"
+  else
+    OUT=$(realpath -m "$RAW_OUT")
+  fi
 fi
 mkdir -p "$(dirname "$OUT")"
 
@@ -43,13 +49,39 @@ mkdir -p "$(dirname "$OUT")"
 cd "$SCRIPT_DIR"
 
 tmpd=$(mktemp -d)
+trap 'rm -rf "$tmpd"' EXIT
+
+# Copy directories to temporary location and apply excludes
+R1="$tmpd/dir1"
+R2="$tmpd/dir2"
+rsync -a --delete "$DIR1/" "$R1/"
+rsync -a --delete "$DIR2/" "$R2/"
+
+for e in "${EX[@]}"; do
+  for root in "$R1" "$R2"; do
+    find "$root" -regextype posix-extended -depth -regex ".*/$e" \
+      -exec rm -rf {} +
+  done
+done
+
 # git diff --no-index && aha
-git diff --no-index --color=always "$DIR1" "$DIR2" > "$tmpd/d.txt" || true
+git diff --no-index --color=always "$R1" "$R2" > "$tmpd/d.txt" || true
 aha < "$tmpd/d.txt" > "$tmpd/d.html"
 
 # Call Python assembler
-assemble_diff.py diff_template.html.j2 \
-  "$tmpd/d.html" diff_collapse.css diff_collapse.js \
-  "$N1" "$N2" "${EX[@]}" "$OUT"
+EX_ARGS=()
+for e in "${EX[@]}"; do
+  EX_ARGS+=(--exclude "$e")
+done
+
+assemble_diff.py \
+  --template diff_template.html.j2 \
+  --diff-html "$tmpd/d.html" \
+  --css diff_collapse.css \
+  --js diff_collapse.js \
+  --name1 "$N1" \
+  --name2 "$N2" \
+  "${EX_ARGS[@]}" \
+  --output "$OUT"
 
 echo "Generated $OUT"


### PR DESCRIPTION
## Summary
- parse CLI arguments in `assemble_diff.py` with argparse
- call updated flags from bash script
- add portable shebang to the python entrypoint
- treat an output arg ending in '/' as a directory and generate the output filename
- remove temporary directory on script exit
- copy directories to temporary locations with rsync and drop exclude patterns
- document temporary exclusion behavior
- handle `-e` regex patterns when removing files

## Testing
- `python3 -m py_compile assemble_diff.py`
- `bash -n diff_dir_2html.sh`


------
https://chatgpt.com/codex/tasks/task_e_6851b4e0ec2883309990e7f9c45f2fee