### PR TITLE
Include git hashes in diff header

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - `-e PATTERN` can be repeated to exclude files whose path matches a POSIX
 extended regular expression.
 - `<dir1>` and `<dir2>` are the directories to compare.
-- `[output]` optional path to the resulting HTML file. If omitted, a name based on the directory names and git revisions is generated. If the path ends with `/`, the directory is created and a filename is generated automatically.
+- `[output]` optional path to the resulting HTML file. If omitted, the file is named `diff_<dir1>_<dir2>.html` in the current directory. If the path ends with `/`, the directory is created and the filename is generated automatically. Commit hashes for each directory appear in the page header instead of the filename.
 
 Exclude patterns are applied after the directories are copied to a temporary location, so files matching the patterns do not appear in the diff.
 

--- a/assemble_diff.py
+++ b/assemble_diff.py
@@ -5,7 +5,7 @@ import argparse
 import jinja2
 
 def main(template_path, diff_html_path, css_path, js_path,
-         name1, name2, excludes, output_path):
+         name1, name2, hash1, hash2, excludes, output_path):
     # Leer recursos
     with open(template_path) as f:
         tpl = jinja2.Template(f.read())
@@ -19,6 +19,8 @@ def main(template_path, diff_html_path, css_path, js_path,
     rendered = tpl.render(
         name1=name1,
         name2=name2,
+        hash1=hash1,
+        hash2=hash2,
         css=css,
         js=js,
         diff_html=diff_html,
@@ -36,6 +38,8 @@ if __name__ == '__main__':
     parser.add_argument("--js", required=True, help="JS file path")
     parser.add_argument("--name1", required=True, help="Name of first directory")
     parser.add_argument("--name2", required=True, help="Name of second directory")
+    parser.add_argument("--hash1", required=True, help="Git hash of first directory")
+    parser.add_argument("--hash2", required=True, help="Git hash of second directory")
     parser.add_argument("--exclude", action="append", default=[],
                         help="Exclude patterns")
     parser.add_argument("--output", required=True, help="Output HTML path")
@@ -48,6 +52,8 @@ if __name__ == '__main__':
         args.js,
         args.name1,
         args.name2,
+        args.hash1,
+        args.hash2,
         args.exclude,
         args.output,
     )

--- a/diff_dir_2html.sh
+++ b/diff_dir_2html.sh
@@ -33,12 +33,12 @@ H2=$(git -C "$DIR2" rev-parse --short=8 HEAD 2>/dev/null || echo fallback)
 
 # Output path, default relative to original directory
 if [[ -z "$RAW_OUT" ]]; then
-  OUT="$ORIG_PWD/diff_${N1}-${H1}_${N2}-${H2}.html"
+  OUT="$ORIG_PWD/diff_${N1}_${N2}.html"
 else
   if [[ "$RAW_OUT" == */ ]]; then
     OUT_DIR=$(realpath -m "$RAW_OUT")
     mkdir -p "$OUT_DIR"
-    OUT="$OUT_DIR/diff_${N1}-${H1}_${N2}-${H2}.html"
+    OUT="$OUT_DIR/diff_${N1}_${N2}.html"
   else
     OUT=$(realpath -m "$RAW_OUT")
   fi
@@ -81,6 +81,8 @@ done
   --js diff_collapse.js \
   --name1 "$N1" \
   --name2 "$N2" \
+  --hash1 "$H1" \
+  --hash2 "$H2" \
   "${EX_ARGS[@]}" \
   --output "$OUT"
 

--- a/diff_template.html.j2
+++ b/diff_template.html.j2
@@ -6,11 +6,11 @@
 <head>
   <meta http-equiv="Content-Type" content="application/xml+xhtml; charset=UTF-8"/>
   <meta charset="UTF-8">
-  <title>diff :: {{ name1 }} :: {{ name2 }}</title>
+  <title>diff :: {{ name1 }} ({{ hash1 }}) :: {{ name2 }} ({{ hash2 }})</title>
   <style>{{ css }}</style>
 </head>
 <body>
-  <h1>diff :: {{ name1 }} :: {{ name2 }}</h1>
+  <h1>diff :: {{ name1 }} ({{ hash1 }}) :: {{ name2 }} ({{ hash2 }})</h1>
   <div id="diff-content">
     <pre>
       {{ diff_html | safe }}


### PR DESCRIPTION
## Summary
- default output file no longer includes git hashes
- pass commit hashes through `assemble_diff.py`
- display hashes in HTML title and header
- update documentation
- revert example output as requested

## Testing
- `./diff_dir_2html.sh example/case1 example/case2 example/out.html`
- `python3 assemble_diff.py --help`
- `./diff_dir_2html.sh example/case1 example/case2`


------
https://chatgpt.com/codex/tasks/task_e_68534e70ac948330add43c15faf91a69