### PR TITLE
Fix diff paths to use original directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ extended regular expression.
 - `[output]` optional path to the resulting HTML file. If omitted, the file is named `diff_<dir1>_<dir2>.html` in the current directory. If the path ends with `/`, the directory is created and the filename is generated automatically. Commit hashes for each directory appear in the page header instead of the filename.
 
 Exclude patterns are applied after the directories are copied to a temporary location, so files matching the patterns do not appear in the diff.
+Temporary paths are stripped from the diff output so that file references show the original directory names.
 
 The script produces an HTML page where every file diff can be expanded or collapsed individually.
 

--- a/diff_collapse.js
+++ b/diff_collapse.js
@@ -2,7 +2,7 @@ document.addEventListener("DOMContentLoaded", function() {
 
   // Collapsible sections
   document.querySelectorAll('pre').forEach(function(pre) {
-    var html = pre.innerHTML.replace(/tmp\/tmp[^\/]+\//g, '');
+    var html = pre.innerHTML;
     var parts = html.split(/(diff --git a\/\S+ b\/\S+)/);
     if (parts.length > 1) {
       var out = '';

--- a/diff_dir_2html.sh
+++ b/diff_dir_2html.sh
@@ -69,7 +69,11 @@ done
 
 # git diff --no-index && aha
 git diff --no-index --color=always "$R1" "$R2" > "$tmpd/d.txt" || true
-aha --no-header < "$tmpd/d.txt" > "$tmpd/d.html"
+# Replace temporary paths with the original directory names for clarity
+ESC_R1=$(printf '%s\n' "$R1" | sed 's/[\\/&]/\\&/g')
+ESC_R2=$(printf '%s\n' "$R2" | sed 's/[\\/&]/\\&/g')
+sed -e "s|$ESC_R1|/$N1|g" -e "s|$ESC_R2|/$N2|g" "$tmpd/d.txt" \
+  | aha --no-header > "$tmpd/d.html"
 
 # Call Python assembler
 EX_ARGS=()


### PR DESCRIPTION
## Summary
- replace temporary dir names in diffs with actual directory names
- drop JS cleanup of `/tmp` paths
- document behaviour in README
- escape sed substitution for robustness
- streamline sed and aha invocation

## Testing
- `bash -n diff_dir_2html.sh`
- `bash diff_dir_2html.sh example/case1 example/case2 /tmp/out2.html`
- `GIT_DIR=/nonexistent bash diff_dir_2html.sh example/case1 example/case2 /tmp/out_fallback2.html`
- ⚠️ `shellcheck diff_dir_2html.sh` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c8c82b9188330bb3c036870ea3e02