### PR TITLE
Exclude .git and other VCS directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ extended regular expression.
 - `[output]` optional path to the resulting HTML file. If omitted, the file is named `diff_<dir1>_<dir2>.html` in the current directory. If the path ends with `/`, the directory is created and the filename is generated automatically. Commit hashes for each directory appear in the page header instead of the filename.
 
 Exclude patterns are applied after the directories are copied to a temporary location, so files matching the patterns do not appear in the diff.
+Version control directories such as `.git/`, `.hg/`, `.svn/`, `.bzr/` and `CVS/` are skipped automatically to keep the diff free from repository metadata.
 Temporary paths are stripped from the diff output so that file references show the original directory names.
 
 The script produces an HTML page where every file diff can be expanded or collapsed individually.

--- a/diff_dir_2html.sh
+++ b/diff_dir_2html.sh
@@ -54,11 +54,15 @@ cd "$SCRIPT_DIR"
 tmpd=$(mktemp -d)
 trap 'rm -rf "$tmpd"' EXIT
 
-# Copy directories to temporary location and apply excludes
+# Copy directories to temporary location and ignore common VCS metadata
 R1="$tmpd/dir1"
 R2="$tmpd/dir2"
-rsync -a --delete "$DIR1/" "$R1/"
-rsync -a --delete "$DIR2/" "$R2/"
+rsync -a --delete \
+  --exclude='.git/' --exclude='.hg/' --exclude='.svn/' --exclude='.bzr/' --exclude='CVS/' \
+  "$DIR1/" "$R1/"
+rsync -a --delete \
+  --exclude='.git/' --exclude='.hg/' --exclude='.svn/' --exclude='.bzr/' --exclude='CVS/' \
+  "$DIR2/" "$R2/"
 
 for e in "${EX[@]}"; do
   for root in "$R1" "$R2"; do


### PR DESCRIPTION
## Summary
- avoid copying VCS folders when preparing directories for diff

## Testing
- `bash diff_dir_2html.sh example/case1 example/case2 out.html`


------
https://chatgpt.com/codex/tasks/task_e_6862d5b1eb348330b6fce4fc8d8966c5