### PR TITLE
Implement multi-level collapsible diff sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Exclude patterns are applied after the directories are copied to a temporary loc
 Version control directories such as `.git/`, `.hg/`, `.svn/`, `.bzr/` and `CVS/` are skipped automatically to keep the diff free from repository metadata.
 Temporary paths are stripped from the diff output so that file references show the original directory names.
 
-The script produces an HTML page where every file diff can be expanded or collapsed individually.
+The script produces an HTML page where directories, files and even individual hunks can be expanded or collapsed. Sections are nested to mirror the directory structure of the compared trees.
 
 ## Requirements
 
@@ -34,6 +34,10 @@ The script produces an HTML page where every file diff can be expanded or collap
 - `diff_style.css` – minimal styles for the page.
 
 The HTML template `diff_template.html.j2` and optional stylesheet `diff_style.css` are expected to be present when invoking the script.
+
+### Collapsible hierarchy
+
+The HTML diff is organised to mirror the directory tree. Directories, files and even individual hunks are collapsible sections nested inside one another. The root directory is expanded by default so you can immediately browse the top-level files.
 
 ## Example and CI/CD
 

--- a/diff_collapse.js
+++ b/diff_collapse.js
@@ -1,31 +1,88 @@
-document.addEventListener("DOMContentLoaded", function() {
+document.addEventListener("DOMContentLoaded", function () {
+  const pre = document.querySelector('#diff-content pre');
+  if (!pre) return;
+  const html = pre.innerHTML;
 
-  // Collapsible sections
-  document.querySelectorAll('pre').forEach(function(pre) {
-    var html = pre.innerHTML;
-    var parts = html.split(/(diff --git a\/\S+ b\/\S+)/);
-    if (parts.length > 1) {
-      var out = '';
-      parts.forEach(function(chunk, i) {
-        if (i % 2 === 1) {
-          var headerLine = chunk;
-          var m = headerLine.match(/diff --git a\/(\S+) b\//);
-          var title = m ? m[1] : headerLine;
-          out += '<div class="section">'
-               + '<div class="toggle">' + title + '</div>'
-               + '<div class="content"><pre>' + headerLine + '</pre>';
-        } else {
-            out += '<pre>' + chunk + '</pre>';
-            if (i > 1) out += '</div></div>';
-        }
-      });
-      pre.outerHTML = out;
-      document.querySelectorAll('.toggle').forEach(function(t) {
-        t.addEventListener('click', function() {
-          t.parentNode.classList.toggle('open');
-        });
-      });
-    }
+  // Split diff output into individual file sections
+  const parts = html.split(/(<span[^>]*>diff --git a\/\S+ b\/\S+<\/span>)/);
+  const files = [];
+  for (let i = 1; i < parts.length; i += 2) {
+    const header = parts[i];
+    const body = parts[i + 1] || '';
+    const m = header.match(/diff --git a\/(\S+) b\//);
+    const path = m ? m[1] : 'unknown';
+    files.push({ path: path, html: header + body });
+  }
+
+  // Build directory tree from file paths
+  const root = { dirs: {}, files: [] };
+  files.forEach(function (f) {
+    const segments = f.path.split('/');
+    const fileName = segments.pop();
+    let node = root;
+    segments.forEach(function (seg) {
+      if (!node.dirs[seg]) node.dirs[seg] = { dirs: {}, files: [] };
+      node = node.dirs[seg];
+    });
+    node.files.push({ name: fileName, html: f.html });
   });
 
+  function stripTags(str) {
+    const tmp = document.createElement('div');
+    tmp.innerHTML = str;
+    return tmp.textContent || tmp.innerText || '';
+  }
+
+  function renderHunks(fileHtml) {
+    const parts = fileHtml.split(/(<span[^>]*>@@[^@]*@@<\/span>)/);
+    const hunks = [];
+    const preamble = parts[0];
+    if (parts.length <= 1) {
+      hunks.push({ header: stripTags(preamble), html: fileHtml });
+    } else {
+      for (let j = 1; j < parts.length; j += 2) {
+        const chunk = (j === 1 ? preamble : '') + parts[j] + (parts[j + 1] || '');
+        hunks.push({ header: stripTags(parts[j]), html: chunk });
+      }
+    }
+    return hunks;
+  }
+
+  function renderFile(name, html) {
+    let out = '<div class="section file">';
+    out += '<div class="toggle">' + name + '</div>';
+    out += '<div class="content">';
+    renderHunks(html).forEach(function (h) {
+      out += '<div class="section hunk">';
+      out += '<div class="toggle">' + h.header + '</div>';
+      out += '<div class="content"><pre>' + h.html + '</pre></div>';
+      out += '</div>';
+    });
+    out += '</div></div>';
+    return out;
+  }
+
+  function renderDir(name, node, isRoot) {
+    let out = '<div class="section dir' + (isRoot ? ' open root' : '') + '">';
+    if (!isRoot) {
+      out += '<div class="toggle">' + name + '</div>';
+    }
+    out += '<div class="content">';
+    Object.keys(node.dirs).sort().forEach(function (d) {
+      out += renderDir(d, node.dirs[d], false);
+    });
+    node.files.forEach(function (f) {
+      out += renderFile(f.name, f.html);
+    });
+    out += '</div></div>';
+    return out;
+  }
+
+  pre.outerHTML = renderDir('', root, true);
+
+  document.addEventListener('click', function (e) {
+    if (e.target.classList.contains('toggle')) {
+      e.target.parentNode.classList.toggle('open');
+    }
+  });
 });

--- a/diff_style.css
+++ b/diff_style.css
@@ -20,6 +20,7 @@ body {
     color: var(--zenburn-accent);
     border-left: 3px solid var(--zenburn-accent);
     transition: background 0.3s, color 0.3s;
+    word-break: break-all;
 }
 
 .toggle:hover {
@@ -29,12 +30,17 @@ body {
 
 .content {
     display: none;
-    margin-left: 1em;
     padding: 0.4em;
     background-color: #2b2b2b;
     color: var(--zenburn-muted);
     border-left: 2px solid var(--zenburn-highlight);
+    margin-left: 1em;
 }
+
+.section.root > .content { margin-left: 0; }
+.section.dir > .content { margin-left: 0.5em; }
+.section.file > .content { margin-left: 1em; }
+.section.hunk > .content { margin-left: 1.5em; }
 
 .section.open .content {
     display: block;
@@ -44,4 +50,8 @@ body {
     body { font-size: 16px; }
     .toggle { padding: 0.6em 0.8em; }
     .content { margin-left: 2em; }
+    .section.root > .content { margin-left: 0; }
+    .section.dir > .content { margin-left: 1em; }
+    .section.file > .content { margin-left: 2em; }
+    .section.hunk > .content { margin-left: 3em; }
 }


### PR DESCRIPTION
## Summary
- parse diffs by directory and split hunks in `diff_collapse.js`
- style nested directory, file and hunk sections
- document new collapsing behaviour in README
- attach a single event listener for toggle handling
- root directory section opens by default

## Testing
- `./diff_dir_2html.sh example/case1 example/case2 /tmp/out.html`

------
https://chatgpt.com/codex/tasks/task_e_68682572ad8c8330a16d92e78a01f8e4